### PR TITLE
fix(cli): honor CM_OFFLINE/CM_YES env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,8 @@ out/
 .cache/
 *.traineddata
 
+# Stryker (mutation testing)
+.stryker-tmp/
+
 # Generated docs
 docs/api/

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -111,11 +111,14 @@ program.hook('preAction', (_thisCommand, actionCommand) => {
       ? actionCommand.optsWithGlobals()
       : actionCommand.opts();
 
+  const offline = Boolean(opts.offline) || process.env.CM_OFFLINE === '1';
+  const yes = Boolean(opts.yes) || process.env.CM_YES === '1';
+
   setCliRuntime({
     json: Boolean(opts.json),
     verbose: Boolean(opts.verbose),
-    offline: Boolean(opts.offline),
-    yes: Boolean(opts.yes),
+    offline,
+    yes,
     isTty: Boolean(process.stderr.isTTY),
     startTime: Date.now(),
     command: getCommandPath(actionCommand),
@@ -123,14 +126,10 @@ program.hook('preAction', (_thisCommand, actionCommand) => {
 
   if (opts.offline) {
     process.env.CM_OFFLINE = '1';
-  } else {
-    delete process.env.CM_OFFLINE;
   }
 
   if (opts.yes) {
     process.env.CM_YES = '1';
-  } else {
-    delete process.env.CM_YES;
   }
 
   // In JSON mode, stdout must remain machine-readable (no logs/spinners).

--- a/tests/integration/cli/on-demand-assets.test.ts
+++ b/tests/integration/cli/on-demand-assets.test.ts
@@ -277,6 +277,25 @@ describe('on-demand assets', () => {
     expect(parsed.errors[0].code).toBe('OFFLINE');
   }, 90_000);
 
+  it('CM_OFFLINE=1 hooks download fails (env offline)', async () => {
+    const outDir = join(process.cwd(), 'tests', '.tmp', 'on-demand-assets', 'hooks-offline-env');
+    rmSync(outDir, { recursive: true, force: true });
+    mkdirSync(outDir, { recursive: true });
+
+    const hooksDir = join(outDir, 'hooks');
+
+    const result = await runCli(
+      ['hooks', 'download', 'no-crunch', '--hooks-dir', hooksDir, '--json'],
+      { CM_OFFLINE: '1' },
+      60000
+    );
+
+    expect(result.code).toBe(1);
+    const parsed = assertPureJson(result.stdout);
+    expect(parsed.command).toBe('hooks:download');
+    expect(parsed.errors[0].code).toBe('OFFLINE');
+  }, 90_000);
+
   it('cm --offline setup whisper --json fails fast (no downloads)', async () => {
     const outDir = join(
       process.cwd(),


### PR DESCRIPTION
- Respect CM_OFFLINE/CM_YES when computing CLI runtime flags\n- Add integration coverage for env-driven offline mode\n- Ignore Stryker temp dir to avoid dirty working trees