### PR TITLE
chore(ci): dispatch checks for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: CodeQL
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,15 @@ name: Dependency Review
 
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref to diff against (e.g. master)
+        required: true
+        default: master
+      head_ref:
+        description: Head ref to diff (optional; defaults to dispatch ref)
+        required: false
 
 permissions:
   contents: read
@@ -10,9 +19,15 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base_ref || github.base_ref }}
+      HEAD_REF: ${{ github.event_name == 'workflow_dispatch' && (inputs.head_ref || github.ref_name) || github.head_ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
+        with:
+          base-ref: ${{ env.BASE_REF }}
+          head-ref: ${{ env.HEAD_REF }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,13 +7,67 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Dispatch required checks for release PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const baseBranch = context.payload.repository.default_branch;
+            const prefix = `release-please--branches--${baseBranch}--components--`;
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              base: baseBranch,
+              per_page: 100,
+            });
+
+            const releasePrs = pulls.filter((pr) => pr.head.ref.startsWith(prefix));
+            if (releasePrs.length === 0) {
+              core.info('No open release-please PR found; skipping dispatch.');
+              return;
+            }
+
+            for (const pr of releasePrs) {
+              core.info(`Dispatching workflows for PR #${pr.number} on ref ${pr.head.ref}`);
+
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: 'ci.yml',
+                ref: pr.head.ref,
+              });
+
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: 'codeql.yml',
+                ref: pr.head.ref,
+              });
+
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: 'dependency-review.yml',
+                ref: pr.head.ref,
+                inputs: {
+                  base_ref: pr.base.ref,
+                  head_ref: pr.head.ref,
+                },
+              });
+            }


### PR DESCRIPTION
Release-please creates PRs via GITHUB_TOKEN, which does not trigger other workflows; branch protection then blocks merges.

This PR:
- Adds workflow_dispatch to CI/CodeQL/Dependency Review
- Updates Release Please workflow to dispatch those checks for the open release-please PR ref