### PR TITLE
chore(prettier): ignore CHANGELOG

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,4 @@ validate.json
 *.d.ts
 pnpm-lock.yaml
 package-lock.json
+CHANGELOG.md


### PR DESCRIPTION
Release Please rewrites CHANGELOG.md, which can trip Prettier\u2019s --check and block the release PR. This ignores CHANGELOG.md in Prettier so the release PR can merge cleanly under branch protection.