### PR TITLE
chore(ci): run checks for release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  pull_request_target:
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,11 +20,21 @@ jobs:
   quality:
     name: Quality Gates
     runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name != 'pull_request_target' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'release-please--')
+        )
+      }}
     env:
       HUSKY: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  pull_request_target:
+    branches: [master]
   schedule:
     - cron: '24 3 * * 1'
 
@@ -22,9 +24,19 @@ jobs:
   analyze:
     name: Analyze (CodeQL)
     runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name != 'pull_request_target' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'release-please--')
+        )
+      }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,8 @@ name: Dependency Review
 
 on:
   pull_request:
+  pull_request_target:
+    branches: [master]
   workflow_dispatch:
     inputs:
       base_ref:
@@ -19,12 +21,22 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name != 'pull_request_target' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'release-please--')
+        )
+      }}
     env:
-      BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base_ref || github.base_ref }}
-      HEAD_REF: ${{ github.event_name == 'workflow_dispatch' && (inputs.head_ref || github.ref_name) || github.head_ref }}
+      BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base_ref || github.event.pull_request.base.ref }}
+      HEAD_REF: ${{ github.event_name == 'workflow_dispatch' && (inputs.head_ref || github.ref_name) || github.event.pull_request.head.ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4


### PR DESCRIPTION
GitHub does not trigger pull_request workflows for PRs created by Actions (GITHUB_TOKEN), so release-please PRs can get stuck.

This adds pull_request_target gated to same-repo + release-please branches, and checks out the PR head SHA so CI/CodeQL/Dependency Review run normally and satisfy branch protection.