### PR TITLE
fix(ci): avoid duplicate checks on release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{
-        github.event_name != 'pull_request_target' ||
+        (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')) &&
         (
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'release-please--')
+          github.event_name != 'pull_request_target' ||
+          (
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.head_ref, 'release-please--')
+          )
         )
       }}
     env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,10 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{
-        github.event_name != 'pull_request_target' ||
+        (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')) &&
         (
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'release-please--')
+          github.event_name != 'pull_request_target' ||
+          (
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.head_ref, 'release-please--')
+          )
         )
       }}
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,10 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{
-        github.event_name != 'pull_request_target' ||
+        (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')) &&
         (
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'release-please--')
+          github.event_name != 'pull_request_target' ||
+          (
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.head_ref, 'release-please--')
+          )
         )
       }}
     env:


### PR DESCRIPTION
With pull_request_target enabled for release-please PRs, a human branch update can trigger both pull_request and pull_request_target. Since CI/CodeQL use the same concurrency group, one run gets cancelled and the required check becomes red.

This skips pull_request jobs when the head ref starts with release-please--, so release PRs are validated only via the gated pull_request_target path.