### PR TITLE
fix(ci): restore required check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Quality Gates
@@ -30,10 +33,6 @@ jobs:
       }}
     env:
       HUSKY: 0
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [20, 22]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -43,26 +42,30 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 20
           cache: npm
 
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit (high/critical)
+        run: npm audit --audit-level=high
+        continue-on-error: true
+
       - name: Typecheck
         run: npm run typecheck
-
-      - name: Build CLI
-        run: npm run build
-
-      - name: Build types
-        run: npm run build:types
 
       - name: Lint
         run: npm run lint
 
       - name: Format check
         run: npm run format:check
+
+      - name: Build
+        run: npm run build
+
+      - name: Build types
+        run: npm run build:types
 
       - name: Test with coverage
         run: npm run test:coverage

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,12 +12,13 @@ on:
     - cron: '23 4 * * 1'
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (CodeQL)
     runs-on: ubuntu-latest
     if: >-
       ${{


### PR DESCRIPTION
Branch protection requires check-runs named `Quality Gates` and `Analyze (CodeQL)`, but CI/CodeQL workflows were changed to a matrix/job name that produced different check names (blocking auto-merge and Dependabot).

This PR:
- Removes CI matrix so the check is `Quality Gates`
- Renames CodeQL job to `Analyze (CodeQL)`
- Restores minimal workflow permissions + audit step
