### PR TITLE
chore: reduce Dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,22 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+    ignore:
+      # React 19 currently conflicts with the React/Remotion stack in this repo.
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/react-dom'
+        update-types: ['version-update:semver-major']
+
+      # Avoid broken PRs where coverage major requires a coordinated Vitest major upgrade.
+      - dependency-name: 'vitest'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@vitest/coverage-v8'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ out/
 
 # Stryker (mutation testing)
 .stryker-tmp/
+stryker.conf.cjs
+.stryker-net-patch.cjs
+reports/
 
 # Generated docs
 docs/api/


### PR DESCRIPTION
- Ignore React major bumps (currently incompatible with Remotion/React 18 stack)\n- Ignore Vitest/Coverage major bumps (requires coordinated major upgrade)\n- Ignore local Stryker artifacts in .gitignore